### PR TITLE
add shebang and set -uexo pipefail

### DIFF
--- a/install-riscv.sh
+++ b/install-riscv.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Ubuntu使用下列命令
 # sudo apt-get install autoconf automake autotools-dev curl python3 libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev
 
@@ -6,6 +8,9 @@
 
 # Arch使用下列命令
 # sudo pacman -Syyu autoconf automake curl python3 libmpc mpfr gmp gawk base-devel bison flex texinfo gperf libtool patchutils bc zlib expat
+
+# 设置该脚本：在遇到未定义变量时报错、在出错时终止脚本运行、打印当前执行的语句、将管道中的子命令的错误也视为错误
+set -uexo pipefail
 
 # 进入~目录
 cd


### PR DESCRIPTION
避免在 build 出错时脚本仍然继续运行且打印出有误导性的 Compilation Complete!

手机党，修改完后没有验证过

关于 set -uexo pipefail： http://blog.kablamo.org/2015/11/08/bash-tricks-eux/