### PR TITLE
Update install-riscv-2.sh

### DIFF
--- a/install-riscv-2.sh
+++ b/install-riscv-2.sh
@@ -4,7 +4,7 @@
 # sudo apt-get install autoconf automake autotools-dev curl python3 libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev libglib2.0-dev clang ninja-build 
 
 # Fedora/CentOS/RHEL使用下列命令
-# sudo yum install autoconf automake python3 libmpc-devel mpfr-devel gmp-devel gawk  bison flex texinfo patchutils gcc gcc-c++ zlib-devel expat-devel
+# sudo yum install autoconf automake python3 libmpc-devel mpfr-devel gmp-devel gawk  bison flex texinfo patchutils gcc gcc-c++ zlib-devel expat-devel glib2-devel ninja-build boost
 
 # Arch使用下列命令
 # sudo pacman -Syyu autoconf automake curl python3 libmpc mpfr gmp gawk base-devel bison flex texinfo gperf libtool patchutils bc zlib expat ninja boost


### PR DESCRIPTION
 在fedora下，缺少boost,glib2-devel,ninja-build软件导致编译环境缺失